### PR TITLE
Use latest irishealth-community because previous one has vanished

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=containers.intersystems.com/intersystems/irishealth-community:2021.2.0.651.0
+ARG IMAGE=containers.intersystems.com/intersystems/irishealth-community:2022.1.0.140.0
 
 FROM $IMAGE
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=containers.intersystems.com/intersystems/irishealth-community:2022.1.0.140.0
+ARG IMAGE=intersystemsdc/irishealth-community:latest
 
 FROM $IMAGE
 


### PR DESCRIPTION
I wish ISC wouldn't remove containers from their registry without good reason and notification...