### PR TITLE
Prevent eager prompting for language server install in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,6 +20,7 @@
 		"objectscript.conn" :{
 			"server": "devcontainer",
 			"active": true,
+			"ignoreInstallLanguageServer": true,
 		},
 		"intersystems.servers": {
 			"devcontainer": {
@@ -28,7 +29,7 @@
 				"webServer": {
 					"scheme": "http",
 					"host": "127.0.0.1",
-					"port": 52773
+					"port": 52773,
 				},
 			},
 		},


### PR DESCRIPTION
Before this change, when reopening in devcontainer the ObjectScript extension's activation before Language Server had finished installing caused an extra prompt to install LS.