### PR TITLE
Disable XSRF check by Jupyter server we run in the container

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,6 @@ cd ${SRC_PATH}/src/Python/flask
 
 ${PYTHON_PATH} -m gunicorn --bind "0.0.0.0:8080" wsgi:app &
 
-/home/irisowner/.local/bin/jupyter-notebook --no-browser --port=8888 --ip 0.0.0.0 --notebook-dir=/irisdev/app/src/Notebooks --NotebookApp.token='' --NotebookApp.password='' &
+/home/irisowner/.local/bin/jupyter-notebook --no-browser --port=8888 --ip 0.0.0.0 --notebook-dir=/irisdev/app/src/Notebooks --NotebookApp.token='' --NotebookApp.password='' --NotebookApp.disable_check_xsrf=True &
 
 fg %1


### PR DESCRIPTION
This allows a local VS Code's Jupyter extension to connect to http://localhost:8888 as a remote Jupyter server after clicking here with a notebook open:

![image](https://user-images.githubusercontent.com/6726799/160106953-dfcab8e8-103b-49fc-9228-86b93ef4919c.png)
